### PR TITLE
内壁の応答係数作成時の外側熱伝達抵抗の算出時に配列を生成してしまう問題の修正 #330

### DIFF
--- a/src/heat_load_calc/core/response_factor.py
+++ b/src/heat_load_calc/core/response_factor.py
@@ -549,8 +549,8 @@ class ResponseFactorFactory:
 
             layers = spec['layers']
 
-            rear_h_c = h_c_js[spec['rear_surface_boundary_id']]
-            rear_h_r = h_r_js[spec['rear_surface_boundary_id']]
+            rear_h_c = h_c_js[spec['rear_surface_boundary_id'], 0]
+            rear_h_r = h_r_js[spec['rear_surface_boundary_id'], 0]
 
             return ResponseFactorFactoryTransientEnvelope(
                 cs=[float(layer['thermal_capacity']) for layer in layers],


### PR DESCRIPTION
内壁の応答係数作成時の外側熱伝達抵抗の算出時に配列を生成してしまう問題を修正しました。